### PR TITLE
fix: remove image pull secrets from Operator chart

### DIFF
--- a/charts/carthago-op-jenkins/templates/operator.yaml
+++ b/charts/carthago-op-jenkins/templates/operator.yaml
@@ -17,10 +17,6 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       serviceAccountName: service-account
-    {{- with .Values.operator.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ .Values.operator.image }}

--- a/charts/carthago-op-jenkins/values.yaml
+++ b/charts/carthago-op-jenkins/values.yaml
@@ -14,10 +14,6 @@ operator:
   # imagePullPolicy defines policy for pulling images
   imagePullPolicy: IfNotPresent
 
-  # imagePullSecrets is used to pull images from private repository
-  imagePullSecrets:
-    - name: token
-
   # command
   command:
     - /manager


### PR DESCRIPTION
This field was necessary when we were using private image registry to store Operator image, but now is redundant