### PR TITLE
Watching all namespaces

### DIFF
--- a/charts/carthago-op-jenkins/templates/_helpers.tpl
+++ b/charts/carthago-op-jenkins/templates/_helpers.tpl
@@ -43,3 +43,11 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+{{- define "carthago-op-jenkins.rolename" -}}
+{{ include "carthago-op-jenkins.fullname" . }}-op-role
+{{- end -}}
+
+{{- define "carthago-op-jenkins.rolebindingname" -}}
+{{ include "carthago-op-jenkins.fullname" . }}-op-rolebinding
+{{- end -}}

--- a/charts/carthago-op-jenkins/templates/operator.yaml
+++ b/charts/carthago-op-jenkins/templates/operator.yaml
@@ -36,7 +36,9 @@ spec:
           {{- end}}
           env:
             - name: WATCH_NAMESPACE
-              value: {{ join "," .Values.operator.watchedNamespaces }}
+              value: {{ join "," .Values.operator.watchedNamespaces | quote }}
+            - name: LABEL_SELECTOR
+              value: {{ .Values.operator.labelSelector | quote }}
             - name: OPERATOR_NAME
               value: "carthago-op-jenkins"
           resources:

--- a/charts/carthago-op-jenkins/templates/role.yaml
+++ b/charts/carthago-op-jenkins/templates/role.yaml
@@ -1,7 +1,7 @@
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: {{ .Values.operator.useClusterRBAC | ternary "ClusterRole" "Role" }} 
 metadata:
   creationTimestamp: null
   name: manager-role
@@ -141,6 +141,7 @@ rules:
       - watch
 
 
+{{- if not .Values.operator.useClusterRBAC }}
 {{- range .Values.operator.watchedNamespaces }}
 {{- if ne . $.Release.Namespace }}
 ---
@@ -284,5 +285,6 @@ rules:
       - list
       - update
       - watch
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/carthago-op-jenkins/templates/role.yaml
+++ b/charts/carthago-op-jenkins/templates/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ .Values.operator.useClusterRBAC | ternary "ClusterRole" "Role" }} 
 metadata:
   creationTimestamp: null
-  name: {{ include "carthago-op-jenkins.fullname" . }}-op-role
+  name: {{ include "carthago-op-jenkins.rolename" . }}
 rules:
   - apiGroups:
       - apps
@@ -149,7 +149,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
-  name: {{ include "carthago-op-jenkins.fullname" . }}-op-role
+  name: {{ include "carthago-op-jenkins.rolename" $ }}
   namespace: {{ . }}
 rules:
   - apiGroups:

--- a/charts/carthago-op-jenkins/templates/role.yaml
+++ b/charts/carthago-op-jenkins/templates/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ .Values.operator.useClusterRBAC | ternary "ClusterRole" "Role" }} 
 metadata:
   creationTimestamp: null
-  name: manager-role
+  name: {{ include "carthago-op-jenkins.fullname" . }}-op-role
 rules:
   - apiGroups:
       - apps
@@ -149,7 +149,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
-  name: manager-role
+  name: {{ include "carthago-op-jenkins.fullname" . }}-op-role
   namespace: {{ . }}
 rules:
   - apiGroups:

--- a/charts/carthago-op-jenkins/templates/role_binding.yaml
+++ b/charts/carthago-op-jenkins/templates/role_binding.yaml
@@ -2,14 +2,15 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ .Values.operator.useClusterRBAC | ternary "ClusterRoleBinding" "RoleBinding" }} 
 metadata:
-  name: manager-rolebinding
+  name: {{ include "carthago-op-jenkins.fullname" . }}-op-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: manager-role
+  kind: {{ .Values.operator.useClusterRBAC | ternary "ClusterRole" "Role" }} 
+  name: {{ include "carthago-op-jenkins.fullname" . }}-op-role
 subjects:
   - kind: ServiceAccount
     name: service-account
+    namespace: {{ $.Release.Namespace }}
 
 {{- if not .Values.operator.useClusterRBAC }}
 {{- range .Values.operator.watchedNamespaces }}
@@ -18,12 +19,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: manager-rolebinding
+  name: {{ include "carthago-op-jenkins.fullname" . }}-op-rolebinding
   namespace: {{ . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: manager-role
+  name: {{ include "carthago-op-jenkins.fullname" . }}-op-role
 subjects:
   - kind: ServiceAccount
     name: service-account

--- a/charts/carthago-op-jenkins/templates/role_binding.yaml
+++ b/charts/carthago-op-jenkins/templates/role_binding.yaml
@@ -2,11 +2,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ .Values.operator.useClusterRBAC | ternary "ClusterRoleBinding" "RoleBinding" }} 
 metadata:
-  name: {{ include "carthago-op-jenkins.fullname" . }}-op-rolebinding
+  name: {{ include "carthago-op-jenkins.rolebindingname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: {{ .Values.operator.useClusterRBAC | ternary "ClusterRole" "Role" }} 
-  name: {{ include "carthago-op-jenkins.fullname" . }}-op-role
+  name: {{ include "carthago-op-jenkins.rolename" . }}
 subjects:
   - kind: ServiceAccount
     name: service-account
@@ -19,12 +19,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "carthago-op-jenkins.fullname" . }}-op-rolebinding
+  name: {{ include "carthago-op-jenkins.rolebindingname" $ }}
   namespace: {{ . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ include "carthago-op-jenkins.fullname" . }}-op-role
+  name: {{ include "carthago-op-jenkins.rolename" $ }}
 subjects:
   - kind: ServiceAccount
     name: service-account

--- a/charts/carthago-op-jenkins/templates/role_binding.yaml
+++ b/charts/carthago-op-jenkins/templates/role_binding.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: {{ .Values.operator.useClusterRBAC | ternary "ClusterRoleBinding" "RoleBinding" }} 
 metadata:
   name: manager-rolebinding
 roleRef:
@@ -11,6 +11,7 @@ subjects:
   - kind: ServiceAccount
     name: service-account
 
+{{- if not .Values.operator.useClusterRBAC }}
 {{- range .Values.operator.watchedNamespaces }}
 {{- if ne . $.Release.Namespace }}
 ---
@@ -27,5 +28,6 @@ subjects:
   - kind: ServiceAccount
     name: service-account
     namespace: {{ $.Release.Namespace }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/carthago-op-jenkins/tests/operator_label_selector_test.yaml
+++ b/charts/carthago-op-jenkins/tests/operator_label_selector_test.yaml
@@ -1,0 +1,23 @@
+suite: Operator label selector propagation to LABEL_SELECTOR env
+templates:
+  - operator.yaml
+values:
+  - values/operator/default.yaml
+tests:
+  - it: should propagate empty string LABEL_SELECTOR env if not set
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LABEL_SELECTOR
+            value: ""
+  - it: should propagate label selector to env correctly
+    set:
+      operator.labelSelector: "label1=test,label2"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: LABEL_SELECTOR
+            value: "label1=test,label2"
+

--- a/charts/carthago-op-jenkins/tests/operator_watched_ns_test.yaml
+++ b/charts/carthago-op-jenkins/tests/operator_watched_ns_test.yaml
@@ -29,3 +29,12 @@ tests:
           content:
             name: WATCH_NAMESPACE
             value: one,two
+  - it: should propagate empty string correctly to WATCH_NAMESPACE if it's present in values.yaml
+    set:
+      operator.watchedNamespaces: ""
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: WATCH_NAMESPACE
+            value: ""

--- a/charts/carthago-op-jenkins/tests/operator_watched_ns_test.yaml
+++ b/charts/carthago-op-jenkins/tests/operator_watched_ns_test.yaml
@@ -29,9 +29,9 @@ tests:
           content:
             name: WATCH_NAMESPACE
             value: one,two
-  - it: should propagate empty string correctly to WATCH_NAMESPACE if it's present in values.yaml
+  - it: should propagate empty array as empty string correctly to WATCH_NAMESPACE if it's present in values.yaml
     set:
-      operator.watchedNamespaces: ""
+      operator.watchedNamespaces: []
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env

--- a/charts/carthago-op-jenkins/tests/role_binding_test.yaml
+++ b/charts/carthago-op-jenkins/tests/role_binding_test.yaml
@@ -16,7 +16,7 @@ tests:
           value: null
       - equal:
           path: roleRef.name
-          value: manager-role
+          value: RELEASE-NAME-carthago-op-jenkins-op-role
   - it: by default it should create a role binding in jenkins ns
     documentIndex: 1
     asserts:
@@ -27,7 +27,7 @@ tests:
           value: jenkins
       - equal:
           path: roleRef.name
-          value: manager-role
+          value: RELEASE-NAME-carthago-op-jenkins-op-role
   - it: creates role in one ns when op and jenkins is depolyed to the same ns
     set:
       operator.watchedNamespaces: [default]
@@ -58,7 +58,7 @@ tests:
           value: ClusterRoleBinding
   - it: creates one ClusterRoleBinding when useClusterRBAC is set to true and watching all ns
     set:
-      operator.watchedNamespaces: ""
+      operator.watchedNamespaces: []
       operator.useClusterRBAC: true
     asserts:
       - hasDocuments:

--- a/charts/carthago-op-jenkins/tests/role_binding_test.yaml
+++ b/charts/carthago-op-jenkins/tests/role_binding_test.yaml
@@ -37,9 +37,32 @@ tests:
       - equal:
           path: metadata.namespace
           value: null
+      - equal:
+          path: kind
+          value: RoleBinding
   - it: creates roles in all watched namespaces and the operator one
     set:
       operator.watchedNamespaces: [one, two]
     asserts:
       - hasDocuments:
           count: 3
+  - it: creates one ClusterRoleBinding when useClusterRBAC is set to true and multiple ns specified
+    set:
+      operator.watchedNamespaces: [one, two]
+      operator.useClusterRBAC: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: ClusterRoleBinding
+  - it: creates one ClusterRoleBinding when useClusterRBAC is set to true and watching all ns
+    set:
+      operator.watchedNamespaces: ""
+      operator.useClusterRBAC: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: ClusterRoleBinding

--- a/charts/carthago-op-jenkins/tests/role_test.yaml
+++ b/charts/carthago-op-jenkins/tests/role_test.yaml
@@ -16,7 +16,7 @@ tests:
           value: null
       - equal:
           path: metadata.name
-          value: manager-role
+          value: RELEASE-NAME-carthago-op-jenkins-op-role
   - it: by default it should create a role in jenkins ns
     documentIndex: 1
     asserts:
@@ -27,7 +27,7 @@ tests:
           value: jenkins
       - equal:
           path: metadata.name
-          value: manager-role
+          value: RELEASE-NAME-carthago-op-jenkins-op-role
   - it: creates role in one ns when op and jenkins is depolyed to the same ns
     set:
       operator.watchedNamespaces: [default]
@@ -58,7 +58,7 @@ tests:
           value: ClusterRole
   - it: creates one ClusterRole when useClusterRBAC is set to true and watching all ns
     set:
-      operator.watchedNamespaces: ""
+      operator.watchedNamespaces: []
       operator.useClusterRBAC: true
     asserts:
       - hasDocuments:

--- a/charts/carthago-op-jenkins/tests/role_test.yaml
+++ b/charts/carthago-op-jenkins/tests/role_test.yaml
@@ -37,9 +37,32 @@ tests:
       - equal:
           path: metadata.namespace
           value: null
+      - equal:
+          path: kind
+          value: Role
   - it: creates roles in all watched namespaces and the operator one
     set:
       operator.watchedNamespaces: [one, two]
     asserts:
       - hasDocuments:
           count: 3
+  - it: creates one ClusterRole when useClusterRBAC is set to true and multiple ns specified
+    set:
+      operator.watchedNamespaces: [one, two]
+      operator.useClusterRBAC: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: ClusterRole
+  - it: creates one ClusterRole when useClusterRBAC is set to true and watching all ns
+    set:
+      operator.watchedNamespaces: ""
+      operator.useClusterRBAC: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: ClusterRole

--- a/charts/carthago-op-jenkins/values.yaml
+++ b/charts/carthago-op-jenkins/values.yaml
@@ -44,7 +44,7 @@ operator:
   # For more details see https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}
 
-  # watchedNamespaces specifies namespaces that will be watched by the operator, empty string sets the operator to watch all namespaces
+  # watchedNamespaces specifies namespaces that will be watched by the operator, empty array ([]) sets the operator to watch all namespaces
   watchedNamespaces:
     - jenkins
 

--- a/charts/carthago-op-jenkins/values.yaml
+++ b/charts/carthago-op-jenkins/values.yaml
@@ -9,7 +9,7 @@ operator:
   replicaCount: 1
 
   # image is the name (and tag) of the Carthago Operator for Jenkins image
-  image: carthago.azurecr.io/carthago-op-jenkins:0.15.0
+  image: carthago.azurecr.io/carthago-op-jenkins:0.15.1
 
   # imagePullPolicy defines policy for pulling images
   imagePullPolicy: IfNotPresent

--- a/charts/carthago-op-jenkins/values.yaml
+++ b/charts/carthago-op-jenkins/values.yaml
@@ -9,7 +9,7 @@ operator:
   replicaCount: 1
 
   # image is the name (and tag) of the Carthago Operator for Jenkins image
-  image: carthago.azurecr.io/carthago-op-jenkins:0.14.4
+  image: carthago.azurecr.io/carthago-op-jenkins:0.15.0
 
   # imagePullPolicy defines policy for pulling images
   imagePullPolicy: IfNotPresent
@@ -44,9 +44,12 @@ operator:
   # For more details see https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
   affinity: {}
 
-  # watchedNamespaces specifies namespaces that will be watched by the operator
+  # watchedNamespaces specifies namespaces that will be watched by the operator, empty string sets the operator to watch all namespaces
   watchedNamespaces:
     - jenkins
+
+  # labelSelector sets a selector for Operator's Custom Resources, useful when the operator is set to watch all namespaces
+  labelSelector: ""
 
   # licenseSecretName specifies a name for the secret with license key. For paid plan features to be available,
   # a secret with this name containing valid information must be present in the same namespace as Carthago Operator

--- a/charts/carthago-op-jenkins/values.yaml
+++ b/charts/carthago-op-jenkins/values.yaml
@@ -51,6 +51,10 @@ operator:
   # labelSelector sets a selector for Operator's Custom Resources, useful when the operator is set to watch all namespaces
   labelSelector: ""
 
+  # useClusterRBAC, if set to true, will deploy cluster-scoped role and role bindings for the operator's service account.
+  # Set this to true, when configuring the operator to watch all namespaces in the cluster.
+  useClusterRBAC: false
+
   # licenseSecretName specifies a name for the secret with license key. For paid plan features to be available,
   # a secret with this name containing valid information must be present in the same namespace as Carthago Operator
   # is deployed in.


### PR DESCRIPTION
- set the operator to watch all namespaces
- allow the user to use label selector through the helm chart
- allow to create `ClusterRole` and `ClusterRoleBinding` when watching all namespaces