### PR TITLE
feat: configurable PVC names

### DIFF
--- a/charts/carthago-op-jenkins-crs/templates/jenkins.yaml
+++ b/charts/carthago-op-jenkins-crs/templates/jenkins.yaml
@@ -117,7 +117,7 @@ spec:
   {{- with .Values.jenkins.pluginsCache }}
   pluginsCache: {{ toYaml . | nindent 4 }}
   {{- end }}
-  {{- with .Values.jenkins.homePVC }}
+  {{- with .Values.jenkins.pvcSettings }}
   pvcSettings: {{ toYaml . | nindent 4 }}
   {{- end }}
   {{- with .Values.jenkins.roles }}

--- a/charts/carthago-op-jenkins-crs/templates/jenkins.yaml
+++ b/charts/carthago-op-jenkins-crs/templates/jenkins.yaml
@@ -118,7 +118,7 @@ spec:
   pluginsCache: {{ toYaml . | nindent 4 }}
   {{- end }}
   {{- with .Values.jenkins.homePVC }}
-  homePVC: {{ toYaml . | nindent 4 }}
+  pvcSettings: {{ toYaml . | nindent 4 }}
   {{- end }}
   {{- with .Values.jenkins.roles }}
   roles: {{ toYaml . | nindent 4 }}

--- a/charts/carthago-op-jenkins-crs/tests/jenkins_test.yaml
+++ b/charts/carthago-op-jenkins-crs/tests/jenkins_test.yaml
@@ -167,7 +167,7 @@ tests:
             kind: "Role"
             name: role
       - equal:
-          path: spec.homePVC
+          path: spec.pvcSettings
           value:
             name: "example-jenkins-home-claim"
             accessMode: "ReadWriteOnce"

--- a/charts/carthago-op-jenkins-crs/tests/jenkins_test.yaml
+++ b/charts/carthago-op-jenkins-crs/tests/jenkins_test.yaml
@@ -169,11 +169,13 @@ tests:
       - equal:
           path: spec.homePVC
           value:
+            name: "example-jenkins-home-claim"
             accessMode: "ReadWriteOnce"
             resourceStorage: "20Gi"
       - equal:
           path: spec.pluginsCache
           value:
+            name: "example-plugins-cache-claim"
             accessMode: "ReadWriteOnce"
             resourceStorage: "1Gi"
       - contains:

--- a/charts/carthago-op-jenkins-crs/tests/values/jenkins_test_values.yaml
+++ b/charts/carthago-op-jenkins-crs/tests/values/jenkins_test_values.yaml
@@ -111,7 +111,7 @@ jenkins:
         operator: "Equal"
         value: "value1"
         effect: "NoSchedule"
-  homePVC:
+  pvcSettings:
     name: "example-jenkins-home-claim"
     accessMode: "ReadWriteOnce"
     resourceStorage: "20Gi"

--- a/charts/carthago-op-jenkins-crs/tests/values/jenkins_test_values.yaml
+++ b/charts/carthago-op-jenkins-crs/tests/values/jenkins_test_values.yaml
@@ -112,9 +112,11 @@ jenkins:
         value: "value1"
         effect: "NoSchedule"
   homePVC:
+    name: "example-jenkins-home-claim"
     accessMode: "ReadWriteOnce"
     resourceStorage: "20Gi"
   pluginsCache:
+    name: "example-plugins-cache-claim"
     accessMode: "ReadWriteOnce"
     resourceStorage: "1Gi"
   plugins:

--- a/charts/carthago-op-jenkins-crs/values.yaml
+++ b/charts/carthago-op-jenkins-crs/values.yaml
@@ -57,6 +57,9 @@ jenkins:
   # homePVC allows setting PersistentVolumeClaim properties for Jenkins home
   homePVC: {}
 
+  # name of Jenkins Home PVC
+  # name: ""
+
   # accessMode specifies the way Jenkins home Volume can be mounted
   # accessMode: ""
 
@@ -67,9 +70,12 @@ jenkins:
   # storageClassName: ""
   # storageClassName: ""
 
-  # pluginsCache allows setting plugins cache specific pvc properties
+  # pluginsCache allows setting plugins cache specific PVC properties
   # pluginsCache is not available in the free plan and requires a valid license
   pluginsCache: {}
+
+  # name of plugins cache PVC
+  # name: ""
 
   # accessMode specifies the way the plugins cache can be mounted
   # accessMode: ""

--- a/charts/carthago-op-jenkins-crs/values.yaml
+++ b/charts/carthago-op-jenkins-crs/values.yaml
@@ -54,9 +54,8 @@ jenkins:
     priorityClassName: ""
     tolerations: []
 
-  # homePVC allows setting PersistentVolumeClaim properties for Jenkins home
-  homePVC: {}
-
+  # pvcSettings allows setting PersistentVolumeClaim properties for Jenkins home
+  pvcSettings: {}
   # name of Jenkins Home PVC
   # name: ""
 
@@ -70,10 +69,9 @@ jenkins:
   # storageClassName: ""
   # storageClassName: ""
 
-  # pluginsCache allows setting plugins cache specific PVC properties
+  # pluginsCache allows setting PersistentVolumeClaim properties for plugins cache
   # pluginsCache is not available in the free plan and requires a valid license
   pluginsCache: {}
-
   # name of plugins cache PVC
   # name: ""
 


### PR DESCRIPTION
* added name field to Jenkins home PVC settings and plugins cache PVC settings in crs chart
* renamed homePVC in crs chart to pvcSettings
* fixed a bug with homePVC being incompatible with API