### PR TITLE
chore: slightly less error prone release workflow

### DIFF
--- a/.github/workflows/release-helm-chart.yml
+++ b/.github/workflows/release-helm-chart.yml
@@ -6,15 +6,14 @@ on:
       bump:
         type: choice
         required: true
-        description: How to bump the chart version. Setting it to disabled will make the workflow release the charts with versions from chart.yaml files.
+        description: How to bump the chart version.
         options:
-          - disabled
           - major
           - minor
           - patch
       appVersion:
-        description: "Operator app version without quotes, eg. 0.8.1. If not provided, app version already present in Chart.yaml files will be used. If bump was disabled, appVersion won't be changed too."
-        required: false
+        required: true
+        description: Operator app version without quotes, eg. 0.8.1.
 
 jobs:
   release-charts:

--- a/charts/carthago-op-jenkins/values.yaml
+++ b/charts/carthago-op-jenkins/values.yaml
@@ -9,7 +9,7 @@ operator:
   replicaCount: 1
 
   # image is the name (and tag) of the Carthago Operator for Jenkins image
-  image: carthago.azurecr.io/carthago-op-jenkins:0.15.1
+  image: carthago.azurecr.io/carthago-op-jenkins:0.15.3
 
   # imagePullPolicy defines policy for pulling images
   imagePullPolicy: IfNotPresent


### PR DESCRIPTION
* Made appVersion required for release workflow

* Removed disabled option from bump in release workflow

* Bumped Operator image version in values