### PR TITLE
feat: Jenkins pod metadata

### DIFF
--- a/charts/carthago-op-jenkins-crs/templates/jenkins.yaml
+++ b/charts/carthago-op-jenkins-crs/templates/jenkins.yaml
@@ -10,8 +10,8 @@ metadata:
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- with .Values.jenkins.podLabels }}
-  podLabels: {{ toYaml . | nindent 6 }}
+  {{- with .Values.jenkins.podMetadata }}
+  podMetadata: {{ toYaml . | nindent 6 }}
   {{- end }}
   podSpec:
     {{- if .Values.jenkins.podSpec.initContainers }}

--- a/charts/carthago-op-jenkins-crs/tests/jenkins_test.yaml
+++ b/charts/carthago-op-jenkins-crs/tests/jenkins_test.yaml
@@ -29,9 +29,13 @@ tests:
       - values/jenkins_test_values.yaml
     asserts:
       - equal:
-          path: spec.podLabels
+          path: spec.podMetadata.labels
           value:
-            podLabelTestKey: podLabelTestValue
+            labelTestKey: labelTestValue
+      - equal:
+          path: spec.podMetadata.annotations
+          value:
+            annotationTestKey: annotationTestValue
       - contains:
           path: spec.podSpec.initContainers
           content:

--- a/charts/carthago-op-jenkins-crs/tests/values/jenkins_test_values.yaml
+++ b/charts/carthago-op-jenkins-crs/tests/values/jenkins_test_values.yaml
@@ -7,8 +7,11 @@ jenkins:
     labelTestKey: labelTestValue
   annotations:
     annotationsTestKey: annotationsTestValue
-  podLabels:
-    podLabelTestKey: podLabelTestValue
+  podMetadata:
+    labels:
+      labelTestKey: labelTestValue
+    annotations:
+      annotationTestKey: annotationTestValue
   podSpec:
     initContainers:
       - name: init-container-name

--- a/charts/carthago-op-jenkins-crs/values.yaml
+++ b/charts/carthago-op-jenkins-crs/values.yaml
@@ -19,8 +19,10 @@ jenkins:
   # annotations are injected into metadata annotations field
   annotations: {}
 
-  # podLabels are injected into Jenkins Controller Pod's metadata labels field
-  podLabels: {}
+  # labels and annotations propagated to Jenkins Controller pod
+  podMetadata:
+    labels: {}
+    annotations: {}
 
   # podSpec
   podSpec:


### PR DESCRIPTION
Changed podLabels to podMetadata with labels and annotations in preparation for the upcoming API changes.